### PR TITLE
Handle Case Where Map Has Node '0'

### DIFF
--- a/graph.js
+++ b/graph.js
@@ -68,7 +68,7 @@ var Graph = (function (undefined) {
 		var nodes = [],
 		    u = end;
 
-		while (u) {
+		while (u !== undefined) {
 			nodes.push(u);
 			u = predecessors[u];
 		}


### PR DESCRIPTION
Maps sometimes have nodes labelled '0'. Especially if you're converting from a distance matrix.